### PR TITLE
Add housing option to inquiry pages and filters

### DIFF
--- a/app/enquiry/[id]/edit/page.tsx
+++ b/app/enquiry/[id]/edit/page.tsx
@@ -196,6 +196,7 @@ export default function EditEnquiry() {
                 >
                   <option value="Facebook">Facebook</option>
                   <option value="Reference">Reference</option>
+                  <option value="Housing">Housing</option>
                 </select>
               </div>
             </div>

--- a/app/enquiry/list/page.tsx
+++ b/app/enquiry/list/page.tsx
@@ -387,6 +387,7 @@ export default function EnquiryList() {
                 <option value="ALL">All Sources</option>
                 <option value="Facebook">Facebook</option>
                 <option value="Reference">Reference</option>
+                <option value="Housing">Housing</option>
               </select>
               <div className="absolute right-3 top-[34px] pointer-events-none">
                 <svg className="h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">


### PR DESCRIPTION
Add 'Housing' option to source dropdowns on edit and list filter pages for consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-56a67ee4-4b15-4a8c-a49a-8c0bfe8bd022">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-56a67ee4-4b15-4a8c-a49a-8c0bfe8bd022">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

